### PR TITLE
refactor: auth flow with extended errors

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,61 @@
+import ExtendableError from 'es6-error';
+import { NextResponse } from 'next/server';
+
+type ServerErrorParams = {
+  error_message: string;
+  error_type: string;
+  status_code: number;
+  underlyingError?: unknown;
+};
+
+class ServerError extends ExtendableError {
+  params: ServerErrorParams;
+  trace_id?: string;
+
+  constructor(params: ServerErrorParams) {
+    super(params.error_type);
+    this.params = params;
+  }
+
+  toJSON() {
+    return {
+      error_id: this.trace_id,
+      error_message: this.params.error_message,
+      error_type: this.params.error_type,
+      status_code: this.params.status_code,
+    };
+  }
+
+  toNextResponse() {
+    return NextResponse.json(this.toJSON(), {
+      status: this.params.status_code,
+    });
+  }
+}
+
+type ExtendedServerErrorParams = {
+  error?: unknown;
+  message?: string;
+  type?: string;
+};
+
+export class InternalServerError extends ServerError {
+  constructor(params: ExtendedServerErrorParams = {}) {
+    super({
+      error_message: params.message ?? 'Internal server error',
+      error_type: params.type ?? 'INTERNAL_SERVER_ERROR',
+      status_code: 500,
+      underlyingError: params.error,
+    });
+  }
+}
+
+export class BadRequestError extends ServerError {
+  constructor(params: ExtendedServerErrorParams = {}) {
+    super({
+      error_message: params.message ?? 'Bad request',
+      error_type: params.type ?? 'INVALID_REQUEST',
+      status_code: 400,
+    });
+  }
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -8,7 +8,7 @@ type ServerErrorParams = {
   underlyingError?: unknown;
 };
 
-class ServerError extends ExtendableError {
+export class ServerError extends ExtendableError {
   params: ServerErrorParams;
   trace_id?: string;
 

--- a/lib/services/spotify/save-user-info.ts
+++ b/lib/services/spotify/save-user-info.ts
@@ -1,7 +1,7 @@
 import type { Session, User } from '@supabase/supabase-js';
 
+import { BadRequestError, InternalServerError } from '@/lib/errors';
 import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
 
 import { createSupabaseServerClient } from '../supabase/server';
 
@@ -20,36 +20,36 @@ export const saveUserInfo = async ({
 }) => {
   const providerToken = session.provider_token;
   const userMetadata: UserMetadata = user.user_metadata;
-  if (
-    providerToken &&
-    userMetadata.avatar_url &&
-    userMetadata.full_name &&
-    userMetadata.provider_id
-  ) {
-    const cookieStore = cookies();
-    const supabase = createSupabaseServerClient(cookieStore);
-    const { error } = await supabase
-      .from('account')
-      .upsert(
-        {
-          avatar_url: userMetadata.avatar_url,
-          display_name: userMetadata.full_name,
-          provider_refresh_token: session.provider_refresh_token,
-          provider_token: providerToken,
-          spotify_id: userMetadata.provider_id,
-          user_id: user.id,
-        },
-        { onConflict: 'spotify_id' },
-      )
-      .select();
 
-    if (error) {
-      return NextResponse.json(
-        { message: 'Spotify into could not save into account table' },
-        {
-          status: 500,
-        },
-      );
-    }
+  if (
+    !providerToken ||
+    !userMetadata.avatar_url ||
+    !userMetadata.full_name ||
+    !userMetadata.provider_id
+  ) {
+    throw new BadRequestError({
+      message: 'Missing user info',
+    });
+  }
+
+  const supabase = createSupabaseServerClient(cookies());
+
+  const { error } = await supabase
+    .from('account')
+    .upsert(
+      {
+        avatar_url: userMetadata.avatar_url,
+        display_name: userMetadata.full_name,
+        provider_refresh_token: session.provider_refresh_token,
+        provider_token: providerToken,
+        spotify_id: userMetadata.provider_id,
+        user_id: user.id,
+      },
+      { onConflict: 'spotify_id' },
+    )
+    .select();
+
+  if (error) {
+    throw new InternalServerError({ error });
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/themes": "^2.0.2",
     "@supabase/ssr": "^0.0.10",
     "@supabase/supabase-js": "^2.39.0",
+    "es6-error": "^4.1.1",
     "next": "14.0.4",
     "next-themes": "1.0.0-beta.0",
     "ofetch": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@supabase/supabase-js':
     specifier: ^2.39.0
     version: 2.39.0
+  es6-error:
+    specifier: ^4.1.1
+    version: 4.1.1
   next:
     specifier: 14.0.4
     version: 14.0.4(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
@@ -7317,6 +7320,10 @@ packages:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
       next-tick: 1.1.0
+    dev: false
+
+  /es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
     dev: false
 
   /es6-iterator@2.0.3:


### PR DESCRIPTION
Refactors auth flow to use extended errors with those in mind:
- prefer short-circutting when something is missing / goes wrong
- return http responses only from route handlers
