### PR TITLE
feat: dynamically search and import shows from shows page

### DIFF
--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -35,16 +35,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const { isNewAccount } = await saveUserInfo({ session, user });
-
-    if (isNewAccount) {
-      return NextResponse.redirect(
-        new URL('/onboarding/start', request.url).toString(),
-        {
-          status: 301,
-        },
-      );
-    }
+    await saveUserInfo({ session, user });
 
     return NextResponse.redirect(new URL(redirect || '/shows', request.url));
   } catch (error) {

--- a/app/shows/page.tsx
+++ b/app/shows/page.tsx
@@ -1,6 +1,7 @@
 import type { Tables } from '@/types/supabase/database';
 
 import { ShowCard } from '@/components/show-card';
+import SearchField from '@/components/ui/search-field';
 import { DatabaseError } from '@/lib/errors';
 import { getAccountId } from '@/lib/services/account';
 import { createSupabaseServerClient } from '@/lib/services/supabase/server';
@@ -54,6 +55,9 @@ export default async function Page() {
 
   return (
     <Flex direction="column" gap="4">
+      <Flex direction="row" gap="2">
+        <SearchField />
+      </Flex>
       {myShows.length > 0 && (
         <>
           <Heading as="h2" size="6">

--- a/components/ui/search-field.tsx
+++ b/components/ui/search-field.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { saveEpisodes } from '@/lib/services/episode';
+import { fetchEpisodes } from '@/lib/services/podcast-index/fetch-episodes';
+import { searchShow } from '@/lib/services/podcast-index/search-show';
+import { saveShow } from '@/lib/services/show';
+import { createSupabaseBrowserClient } from '@/lib/services/supabase/browser';
+import { Button, Flex, Text, TextField } from '@radix-ui/themes';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { IoIosSearch } from 'react-icons/io';
+
+export default function SearchField() {
+  const [value, setValue] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [warningMessage, setWarningMessage] = useState('');
+  const router = useRouter();
+  const supabase = createSupabaseBrowserClient();
+
+  const onClickHandler = async () => {
+    setWarningMessage('');
+    setLoading(true);
+    const { data } = await supabase
+      .from('show')
+      .select('id')
+      .ilike('title', value)
+      .single();
+    if (data) {
+      router.push(`/shows/${data.id}`);
+    } else {
+      const show = await searchShow(value);
+      setLoading(false);
+      if (!show) {
+        setWarningMessage(
+          'No results. Please try again with complete name of the show.',
+        );
+        return;
+      }
+
+      const savedShow = await saveShow(show);
+      const episodes = await fetchEpisodes(savedShow.podcast_index_guid);
+      await saveEpisodes(episodes, savedShow.id);
+      router.push(`/shows/${savedShow.id}`);
+    }
+  };
+
+  return (
+    <Flex align="start" direction="column" gap="2">
+      <Flex
+        direction={{
+          initial: 'column',
+          sm: 'row',
+        }}
+        gap="4"
+      >
+        <TextField.Root>
+          <TextField.Input
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            placeholder="Search show names..."
+            radius="small"
+            size="2"
+            style={{
+              width: 320,
+            }}
+            value={value}
+          />
+        </TextField.Root>
+        <Button
+          disabled={loading}
+          highContrast
+          onClick={() => onClickHandler()}
+          size={{
+            initial: '2',
+            lg: '2',
+          }}
+          variant="outline"
+        >
+          <IoIosSearch />
+          Search
+        </Button>
+      </Flex>
+      <Text color="red" size="2">
+        {warningMessage}
+      </Text>
+    </Flex>
+  );
+}

--- a/lib/services/podcast-index/search-show.ts
+++ b/lib/services/podcast-index/search-show.ts
@@ -21,7 +21,7 @@ type PodcastIndexResponse = {
 
 export const searchShow = async (
   title: string,
-): Promise<PodcastIndexShowType> => {
+): Promise<PodcastIndexShowType | undefined> => {
   const response = await podcastIndexFetchClient<PodcastIndexResponse>(
     `/search/bytitle`,
     {

--- a/lib/services/show.ts
+++ b/lib/services/show.ts
@@ -55,7 +55,6 @@ export const saveShow = async (show: PodcastIndexShowType) => {
       language: show.language,
       podcast_index_guid: show.podcastGuid,
       publisher: show.author,
-      spotify_id: show.spotifyId,
       title: show.title,
       total_episode: show.episodeCount,
     })
@@ -66,7 +65,8 @@ export const saveShow = async (show: PodcastIndexShowType) => {
     throw new DatabaseError(error);
   }
 
-  await saveShowToImported(data.id, show.spotifyId, show.podcastGuid);
+  // maybe we can keep it for now?
+  // await saveShowToImported(data.id, show.spotifyId, show.podcastGuid);
 
   return data;
 };
@@ -84,32 +84,32 @@ export const bulkSaveShow = async (shows: PodcastIndexShowType[]) => {
     throw new DatabaseError(error);
   }
 
-  data.map(async (item) => {
-    await saveShowToImported(item.id, item.spotify_id, item.podcast_index_guid);
-  });
+  // data.map(async (item) => {
+  //   await saveShowToImported(item.id, item.spotify_id, item.podcast_index_guid);
+  // });
 
   return data;
 };
 
-const saveShowToImported = async (
-  showId: Tables<'show'>['id'],
-  spotifyId: Tables<'show'>['spotify_id'],
-  podcastIndexGuid: string,
-) => {
-  const supabase = createSupabaseServiceClient();
+// const saveShowToImported = async (
+//   showId: Tables<'show'>['id'],
+//   spotifyId: Tables<'show'>['spotify_id'],
+//   podcastIndexGuid: string,
+// ) => {
+//   const supabase = createSupabaseServiceClient();
 
-  const { data, error } = await supabase.from('imported_show').insert({
-    podcast_index_guid: podcastIndexGuid,
-    show: showId,
-    spotify_id: spotifyId,
-  });
+//   const { data, error } = await supabase.from('imported_show').insert({
+//     podcast_index_guid: podcastIndexGuid,
+//     show: showId,
+//     spotify_id: spotifyId,
+//   });
 
-  if (error) {
-    throw new DatabaseError(error);
-  }
+//   if (error) {
+//     throw new DatabaseError(error);
+//   }
 
-  return data;
-};
+//   return data;
+// };
 
 export const getShowWithGuid = async (
   guid: Tables<'show'>['podcast_index_guid'],

--- a/lib/services/spotify/get-user-shows.ts
+++ b/lib/services/spotify/get-user-shows.ts
@@ -1,3 +1,4 @@
+'use server';
 import { FetchError } from 'ofetch';
 
 import { fetchAccount } from '../account';

--- a/types/supabase/database.ts
+++ b/types/supabase/database.ts
@@ -321,7 +321,7 @@ export interface Database {
           language: string | null;
           podcast_index_guid: string;
           publisher: string;
-          spotify_id: string;
+          spotify_id: string | null;
           title: string;
           total_episode: number | null;
         };
@@ -333,7 +333,7 @@ export interface Database {
           language?: string | null;
           podcast_index_guid: string;
           publisher: string;
-          spotify_id: string;
+          spotify_id?: string | null;
           title: string;
           total_episode?: number | null;
         };
@@ -345,7 +345,7 @@ export interface Database {
           language?: string | null;
           podcast_index_guid?: string;
           publisher?: string;
-          spotify_id?: string;
+          spotify_id?: string | null;
           title?: string;
           total_episode?: number | null;
         };


### PR DESCRIPTION
It doesn't have the best UX. We have to search for the exact title name from podcast index otherwise it returns undefined. It's not even possible to show options and let user select the one. In addition to this, we can't search and get one result from spotify. Even though I give the full title it returns bunch of other results to me. That's why I had to remove the parts that we keep track of imprted shows compared to spotify.


https://github.com/experiment-station/beecast/assets/27828319/5369d492-1978-4342-9169-293282db0a67


